### PR TITLE
Workaround to ignore spurious simctl warnings

### DIFF
--- a/spec/fixtures/simctl_bad.json
+++ b/spec/fixtures/simctl_bad.json
@@ -1,6 +1,8 @@
 Install Started
 1%.........20.........40.........60........Install Succeeded
 apply_selection_policy_once: prefer use of removable GPUs
+objc[76557]: Class NSBloopilyBloop is implemented in both /usr/lib/libbloop.dylib (0x1f700e040) and /Library/Apple/System/Library/PrivateFrameworks/CoreBloop.framework/Versions/A/CoreBloop (0x106584688). One of the two will be used. Which one is undefined.
+xcodebuild[46005:809941] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
 {
   "devices" : {
     "iOS 8.1" : [


### PR DESCRIPTION
We've seen a few situations where `pod lib lint` fails while parsing the list of simulators on Apple Silicon Macs:
```
 - ERROR | [iOS] unknown: Encountered an unknown error (859: unexpected token at 'objc[76557]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libamsupport.dylib (0x1f700e098) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1065842c8). One of the two will be used. Which one is undefined.
```
This appears to be caused by extraneous warnings when running `xcrun simctl list -j devices`.

It looks like there was a workaround in https://github.com/CocoaPods/fourflusher/pull/27, but it doesn't cover every type of error. I think it might help to filter out every line before the opening `{`.

This might also be related to [this comment](https://github.com/CocoaPods/CocoaPods/issues/9672#issuecomment-966784920).