### PR TITLE
Update fetch_sims function for stability (M1 improve support)

### DIFF
--- a/lib/fourflusher/find.rb
+++ b/lib/fourflusher/find.rb
@@ -129,7 +129,7 @@ module Fourflusher
 
     # Gets the simulators and transforms the simctl json into Simulator objects
     def fetch_sims
-      raw_list = list(['-j', 'devices'])
+      raw_list = list(['-j', 'devices', '2>/dev/null'])
       regex_union = Regexp.union(LINES_TO_REMOVE)
       filtered_raw_list = raw_list.each_line.reject { |l| l =~ regex_union }.join
 


### PR DESCRIPTION
Actually, in some cases (for example if you use an M1 processor) Some outputs of the command are missing with the formated JSON. The idea, here is to redirect stderr to nothing to have a valid JSON.

How to reproduce : 
- On Bitrise I got this issue when using a M1 Medium Stack and I finally I fix this just by moving to an Intel Medium Stack.
- The problem was blocking the validation process of compiled Pod (because the Pod 

`
pod repo push xxx-build-private-pods XXX-Firebase-ios.podspec --allow-warnings --verbose
`

Original issue : 
`
-> Pod installation complete! There is 1 dependency from the Podfile and 11 total pods installed.
   Building with `xcodebuild`. 
 -> Build-Plugin-Firebase-ios (1.0.3)
    - ERROR | [iOS] unknown: Encountered an unknown error (unexpected token at 'objc[5067]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libamsupport.dylib (0x1fbabb838) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106aa82c8). One of the two will be used. Which one is undefined.
objc[5067]: Class AMSupportURLSession is implemented in both /usr/lib/libamsupport.dylib (0x1fbabb888) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106aa8318). One of the two will be used. Which one is undefined.
objc[5067]: Class AppleTypeCRetimerRestoreInfoHelper is implemented in both /usr/lib/libauthinstall.dylib (0x1fbabb650) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106aa8598). One of the two will be used. Which one is undefined.
objc[5067]: Class AppleTypeCRetimerFirmwareAggregateRequestCreator is implemented in both /usr/lib/libauthinstall.dylib (0x1fbabb6a0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106aa85e8). One of the two will be used. Which one is undefined.
objc[5067]: Class AppleTypeCRetimerFirmwareRequestCreator is implemented in both /usr/lib/libauthinstall.dylib (0x1fbabb6f0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106aa8638). One of the two will be used. Which one is undefined.
objc[5067]: Class ATCRTRestoreInfoFTABFile is implemented in both /usr/lib/libauthinstall.dylib (0x1fbabb740) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106aa8688). One of the two will be used. Which one is undefined.
objc[5067]: Class AppleTypeCRetimerFirmwareCopier is implemented in both /usr/lib/libauthinstall.dylib (0x1fbabb790) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106aa86d8). One of the two will be used. Which one is undefined.
objc[5067]: Class ATCRTRestoreInfoFTABSubfile is implemented in both /usr/lib/libauthinstall.dylib (0x1fbabb7e0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106aa8728). One of the two will be used. Which one is undefined.
'
/Users/vagrant/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/json-2.6.3/lib/json/common.rb:216:in `parse'
/Users/vagrant/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/json-2.6.3/lib/json/common.rb:216:in `parse'
/Users/vagrant/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/fourflusher-2.3.1/lib/fourflusher/find.rb:125:in `fetch_sims'
/Users/vagrant/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/fourflusher-2.3.1/lib/fourflusher/find.rb:101:in `usable_simulators'
/Users/vagrant/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/fourflusher-2.3.1/lib/fourflusher/find.rb:97:in `simulator'
/Users/vagrant/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/fourflusher-2.3.1/lib/fourflusher/xcodebuild.rb:7:in `destination'
/
`